### PR TITLE
ci: remove pnpm cache steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,33 +62,6 @@ jobs:
             type=edge
             type=ref,event=branch
 
-      - name: pnpm cache for docker
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: cache
-        with:
-          path: |
-            pnpm-store-linux-arm64
-            pnpm-store-linux-amd64
-          key: buildkit-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            buildkit-pnpm-
-
-      - name: inject cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@87e6a3bbd976a1476e29b60fe743ab0977034ff5 # v3.1.1
-        with:
-          cache-map: |
-            {
-              "pnpm-store-linux-amd64": {
-                "target": "/.pnpm-store/",
-                "id": "pnpm-linux/amd64"
-              },
-              "pnpm-store-linux-arm64": {
-                "target": "/.pnpm-store/",
-                "id": "pnpm-linux/arm64"
-              }
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:


### PR DESCRIPTION
キャッシュしない方が総実行時間が短かった
